### PR TITLE
fix: Bump l3vpn package version to 1.1.1 and reorder premod callback

### DIFF
--- a/l3vpn/package-meta-data.xml
+++ b/l3vpn/package-meta-data.xml
@@ -1,6 +1,6 @@
 <ncs-package xmlns="http://tail-f.com/ns/ncs-packages">
   <name>l3vpn</name>
-  <package-version>1.1</package-version>
+  <package-version>1.1.1</package-version>
   <description>L3VPN Service Package</description>
   <ncs-min-version>5.5</ncs-min-version>
   <component>

--- a/l3vpn/python/l3vpn/main.py
+++ b/l3vpn/python/l3vpn/main.py
@@ -17,13 +17,12 @@ class ServiceCallbacks(Service):
     @Service.pre_modification
     def cb_pre_modification(self, tctx, op, kp, root, proplist):
         """Docstring Missing."""
-        self.log.info(f"Service premod(service={kp})")
-        service = cd(root, kp)
-        ctx = ServiceContext(log=self.log, root=root, service=service)
-
         if op == 2:
             return  # nothing to do for 'Delete(2)' operation
 
+        self.log.info(f"Service premod(service={kp})")
+        service = cd(root, kp)
+        ctx = ServiceContext(log=self.log, root=root, service=service)
         PreMod(ctx).fill()
 
     @Service.create


### PR DESCRIPTION
PreMod needs to return immediately if delete operation