### PR TITLE
feat!: Integrate Resource Manager for VPN ID allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Cisco NSO service package for orchestrating MPLS Layer 3 VPN (L3VPN) services on Cisco IOS and IOS-XR devices
 
-***_NOTE:_ Not all features for implementating MPLS L3VPN's are implemented. Rather, this package provides a common approach to Service Provider (SP) related configuration required for supporting MPLS L3VPN's for customers**
+***_NOTE:_ Not all features for implementating MPLS L3VPN's are implemented. Rather, this package provides a common approach for Service Provider (SP) related configuration required for supporting MPLS L3VPN's for customers**
 
 ## Overview
 
@@ -10,10 +10,11 @@ A Multiprotocol Label Switching (MPLS) Layer 3 Virtual Private Network (L3VPN) c
 
 ## Features
 
-1. Support's the selection of a ```customer-name``` as a unique identifier for a service instance
+1. Support's the selection of a ```customer-name``` as a unique identifier for a service instance as leafref to ```/ncs:customers/ncs:customer/ncs:id```
 2. Support's the manual entry of a ```service-id``` as a unique identifier for a service instance
-3. Support's the manual entry of a Virtual Private Network (VPN) identifier at the service level
-    1. The ```vpn-id``` is used in automatically generating Route-Target (RT) and Route-Distinguisher (RD) values
+3. Support's the entry of a Virtual Private Network (VPN) identifier at the service level, allocated via the Cisco NSO Resource Manager
+    1. The ```vpn-id``` is used as a requested allocation — the resource manager either reserves that specific ID or generates one
+    2. The ```vpn-id``` is used in automatically generating Route-Target (RT) and Route-Distinguisher (RD) values
 4. Support's the ability to set the maximum number of routes accepted by the L3VPN at the service level (range: 1..5000, default: 100)
     1. Support's the ability to set the warning percentage for the maximum routes (range: 1..100, default: 80)
 5. Support's the manual entry of the Provider Edge (PE) ASN at the service level
@@ -30,6 +31,21 @@ A Multiprotocol Label Switching (MPLS) Layer 3 Virtual Private Network (L3VPN) c
             2. Support's validation that the forwarding address of each static route falls within one of the device interfaces ipv4-prefix or ipv6-prefix
         3. Support's Border Gateway Protocol (BGP) as the Provider Edge (PE) to Customer Edge (CE) routing protocol
             1. Support's re-distribution of ```connected``` and/or ```static``` routes
+
+## Dependencies
+
+### Cisco NSO Resource Manager (5.0+)
+
+This package requires the [Cisco NSO Resource Manager](https://developer.cisco.com/docs/nso/guides/#!resource-manager) package to allocate VPN IDs. The `vpn-id` entered at the service level is used as a requested ID — the resource manager either allocates that specific ID or generates one if not specified.
+
+Install the resource manager package into your NSO runtime, then configure a pool named `primary-vpn-pool`:
+
+```shell
+set resource-pools id-pool primary-vpn-pool range start 100
+set resource-pools id-pool primary-vpn-pool range end 199
+set resource-pools id-pool primary-vpn-pool allocation-method firstfree
+commit
+```
 
 ## Assumptions
 
@@ -64,7 +80,7 @@ make test
 set customers customer Disneyland status active
 
 # configure service
-set services l3vpn Disneyland service01 vpn-id 1
+set services l3vpn Disneyland service01 vpn-id 100
 set services l3vpn Disneyland service01 inet IPv4
 set services l3vpn Disneyland service01 max-routes 100
 set services l3vpn Disneyland service01 max-routes-warning 80

--- a/l3vpn/package-meta-data.xml
+++ b/l3vpn/package-meta-data.xml
@@ -1,6 +1,6 @@
 <ncs-package xmlns="http://tail-f.com/ns/ncs-packages">
   <name>l3vpn</name>
-  <package-version>1.1.1</package-version>
+  <package-version>2.0.0</package-version>
   <description>L3VPN Service Package</description>
   <ncs-min-version>5.5</ncs-min-version>
   <component>
@@ -9,4 +9,7 @@
       <python-class-name>l3vpn.main.Main</python-class-name>
     </application>
   </component>
+  <required-package>
+    <name>resource-manager</name>
+  </required-package>
 </ncs-package>

--- a/l3vpn/python/l3vpn/l3vpn.py
+++ b/l3vpn/python/l3vpn/l3vpn.py
@@ -7,6 +7,7 @@ from itertools import product
 
 from ncs.maagic import ListElement, PresenceContainer
 from ncs.template import Template, Variables
+from resource_manager.service.allocator import Allocator
 
 from .context import ServiceContext
 from .device import Device
@@ -192,7 +193,21 @@ class L3vpn:
         base_vars = []
         base_vars.append(("CUSTOMER-NAME", self.ctx.service.customer_name))
         base_vars.append(("SERVICE-ID", service_id := self.ctx.service.service_id))
-        base_vars.append(("VPN-ID", vpn_id := self.ctx.service.vpn_id))
+
+        # Allocate VPN ID from the resource manager. If the user entered a
+        # VPN ID into the service model, try and allocate that one, else,
+        # generate a new one
+        rma = Allocator(self.ctx.service)
+        vpn_id = (
+            rma
+            .id(request_id=self.ctx.service.vpn_id)
+            .pool('primary-vpn-pool')
+            .allocate(self.ctx.service.service_id)
+        )
+        self.ctx.service.vpn_id = vpn_id
+        self.ctx.log.info(f'Allocated VPN ID {vpn_id} from the resource manager')
+        base_vars.append(("VPN-ID", vpn_id))
+
         base_vars.append(("INET", self.ctx.service.inet))
         base_vars.append(("MAX-ROUTES", self.ctx.service.max_routes))
         base_vars.append(("MAX-ROUTES-WARNING", self.ctx.service.max_routes_warning))
@@ -201,7 +216,7 @@ class L3vpn:
         for device in self.ctx.service.provider_edge.device:
             self.ctx.log.info("Configuring device: ", device.name)
             self.device_ned_id = self.device.get_device_ned_id(device.name)
-            rd = f"{self.network.get_loopback_ip(device.name, 0)}:{self.ctx.service.vpn_id}"
+            rd = f"{self.network.get_loopback_ip(device.name, 0)}:{vpn_id}"
             vrf = self.network.get_vrf_name(device.name, service_id, vpn_id)
             base_vars.append(("DEVICE-NAME", device.name))
 

--- a/l3vpn/src/yang/l3vpn.yang
+++ b/l3vpn/src/yang/l3vpn.yang
@@ -115,8 +115,7 @@ module l3vpn {
       }
 
       leaf vpn-id {
-        tailf:info "VPN identifier - used to derive RT and RD values";
-        mandatory true;
+        tailf:info "VPN identifier - used to derive RT and RD values.";
         type uint16;
       }
 


### PR DESCRIPTION
Require the resource-manager package and allocate vpn-id via the Resource Manager Allocator. Make vpn-id optional in the YANG model, bump package version to 2.0.0, and update README with dependency instructions and example usage